### PR TITLE
DNC status indicator 

### DIFF
--- a/src/components/DonorDetails/index.css
+++ b/src/components/DonorDetails/index.css
@@ -64,12 +64,28 @@
 
 .contact-row {
   display: flex;
+  
 }
 .contact-box {
   padding: 35px 40px;
   min-width: 540px;
   height: auto;
 }
+.dnc-indicator{
+  background-color:#fbdddd;
+  border-radius: 4px;
+  padding: 3px 12px;
+  margin-left: 11px;
+  align-self: flex-start
+  
+}
+.dnc-indicator-text{
+  color: #EB5757;
+  font-weight: bold;
+  font-size: 14px;
+
+}
+
 .indicator {
   background-color: #e4f9ed;
   border-radius: 4px;
@@ -78,12 +94,13 @@
 }
 .indicator-text {
   font-size: 14px;
+  font-weight: bold;
   color: black;
   opacity: 1;
-  line-height: 17px;
 }
 .header-indicator-box {
   display: flex;
+  
 }
 .table-title {
   font-size: 32px;

--- a/src/components/DonorDetails/index.css
+++ b/src/components/DonorDetails/index.css
@@ -71,12 +71,18 @@
   min-width: 540px;
   height: auto;
 }
+.dnc-contact-box{
+  padding: 35px 40px;
+  min-width: 540px;
+  height: auto;
+  border: solid 1px #EB5757;
+}
 .dnc-indicator{
   background-color:#fbdddd;
   border-radius: 4px;
   padding: 3px 12px;
-  margin-left: 11px;
-  align-self: flex-start
+  margin-left: 70%;
+  position: sticky;
   
 }
 .dnc-indicator-text{
@@ -94,8 +100,7 @@
 }
 .indicator-text {
   font-size: 14px;
-  font-weight: bold;
-  color: black;
+  color: #219653;
   opacity: 1;
 }
 .header-indicator-box {

--- a/src/components/DonorDetails/index.js
+++ b/src/components/DonorDetails/index.js
@@ -120,9 +120,11 @@ const Contact = props => {
               {donorContact.preferredContact ? (
                 <PreferenceIndicator />
               ) : null}
+
             </div>
             <p className="text">{handleNull(donorContact.phone)}</p>
           </div>
+          { donorContact.dnc && <DNCIndicator/>}
         </div>
         <div className="contact-row">
           <img src={Email} alt="email" className="contact-icon" />
@@ -150,10 +152,19 @@ const PreferenceIndicator = () => {
     </div>
   )
 }
-export default DonorDetails
+
+const DNCIndicator = () => {
+  return (
+    <div className="dnc-indicator">
+      <div className="dnc-indicator-text">Do Not Contact</div>
+    </div>
+  )
+}
 
 const handleNull = data => {
   if (!data) {
     return '-'
   } else return data
 }
+
+export default DonorDetails

--- a/src/components/DonorDetails/index.js
+++ b/src/components/DonorDetails/index.js
@@ -102,10 +102,11 @@ const Contact = props => {
   const lowerCaseIdType = donorDetails.idType.toLowerCase()
   return (
     <div className="contact-wrapper">
-      <Box className="contact-box">
+      <Box className= {donorContact.dnc ? "dnc-contact-box" : "contact-box"}>
+      {donorContact.dnc && <DNCIndicator/>}
         {lowerCaseIdType.includes('uen') ? (
           <div className="contact-row">
-            <img src={Person} alt="phone" className="contact-icon" />
+            <img src={Person} alt="contact person" className="contact-icon" />
             <div className="single-field">
               <p className="label">Contact Person</p>
               <p className="text">{handleNull(donorContact.contactPerson)}</p>
@@ -117,14 +118,12 @@ const Contact = props => {
           <div className="single-field">
             <div className="header-indicator-box">
               <p className="label">Phone Number</p>{' '}
-              {donorContact.preferredContact ? (
-                <PreferenceIndicator />
-              ) : null}
+              {donorContact.preferredContact && <PreferenceIndicator />}
 
             </div>
             <p className="text">{handleNull(donorContact.phone)}</p>
           </div>
-          { donorContact.dnc && <DNCIndicator/>}
+         
         </div>
         <div className="contact-row">
           <img src={Email} alt="email" className="contact-icon" />


### PR DESCRIPTION
Just add UI elements (indicator and red borders) when DNC status is true. 
If DNC is false/null, default (no border color, no indicator) is shown. 

Currently, there is no data on DNC and preferred contact and contact person because these data are not found in IPC upload file. Need to check with Reach people how they want to include this data into the database. 