### PR TITLE
Prevent assigning a falsy value to the last uploaded variable.

### DIFF
--- a/src/components/UpdateDB/index.js
+++ b/src/components/UpdateDB/index.js
@@ -155,7 +155,7 @@ const UploadMsg = () => {
 
   useEffect(() => {
     getLatestUpload().then((result) => {
-      setLatestUpload(result);
+      if (result) setLatestUpload(result);
     });
   }, []);
 


### PR DESCRIPTION
When there are no previous uploads, the response is undefined.