### PR TITLE
Batch uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2792,6 +2792,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
+    "bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+    },
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "axios": "^0.19.2",
+    "bignumber.js": "^9.0.0",
     "bootstrap": "^4.4.1",
     "date-fns": "^2.14.0",
     "file-saver": "^2.0.2",

--- a/src/components/UpdateDB/FileHandlers.js
+++ b/src/components/UpdateDB/FileHandlers.js
@@ -27,10 +27,6 @@ function FileHandlers(props) {
               'Receipt Serial No' : e['Receipt Serial No'].toString()
             }
           }
-
-          
-          
-          
         })
         console.log(processedArray)      
         return props.loadIpcEntries(processedArray)

--- a/src/components/UpdateDB/Success.js
+++ b/src/components/UpdateDB/Success.js
@@ -15,7 +15,6 @@ const SuccessUpload = (props) => {
   const uploadSummary = props.donorData.summary;
   const minDate = dateVariation(new Date(uploadSummary.minDate));
   const maxDate = dateVariation(new Date(uploadSummary.maxDate));
-
   //pagination
   const entriesPerPage = 15;
   const [currentPage, setCurrentPage] = useState(1);

--- a/src/components/UpdateDB/index.js
+++ b/src/components/UpdateDB/index.js
@@ -74,9 +74,6 @@ const UpdateDb = () => {
           if (res.ok) return res.json();
           else throw new Error("Error in uploading chunk");
         })
-        .then((data) => {
-          return data;
-        });
     };
 
     chunkedIPC.reduce((prev, curr) => {

--- a/src/components/UpdateDB/index.js
+++ b/src/components/UpdateDB/index.js
@@ -59,9 +59,9 @@ const UpdateDb = () => {
       successUpload: null,
     });
     
-    const chunkedIPC = chunk(upload.ipcData, 2);
+    const chunkedIPC = chunk(upload.ipcData, 1000);
     const fetchAChunk = (chunk) => {
-      return fetch(`http://localhost:3001/donations/upload`, {
+      return fetch(`${process.env.REACT_APP_API}/donations/upload`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -185,7 +185,7 @@ const UpdateDb = () => {
 };
 
 const getLatestUpload = async () => {
-  return await fetch(`http://localhost:3001/uploads/latest`, {
+  return await fetch(`${process.env.REACT_APP_API}/uploads/latest`, {
     method: "GET",
     headers: {
       "Content-Type": "application/json",

--- a/src/components/UpdateDB/index.js
+++ b/src/components/UpdateDB/index.js
@@ -93,10 +93,8 @@ const UpdateDb = () => {
   };
 
   const finalResult = (results) => {
-    console.log(results)
     const extractDataResponse = results.map(i => i.data)
     const extractChunkSummary = results.map(i=> i.summary)
-    console.log(extractChunkSummary)
     const flattenDataResponse = extractDataResponse.reduce((acc, val) => acc.concat(val), []);
     const maxDate = new Date(Math.max.apply(null, extractChunkSummary.map(function(e) {
       return new Date(e.maxDate);

--- a/src/components/UpdateDB/index.js
+++ b/src/components/UpdateDB/index.js
@@ -58,13 +58,7 @@ const UpdateDb = () => {
       failedUpload: false,
       successUpload: null,
     });
-    const validateUpSert = (res) => {
-      if (res.ok) {
-        res.json().then((data) => success(data));
-      } else {
-        return failed();
-      }
-    };
+    
     const chunkedIPC = chunk(upload.ipcData, 2);
     const fetchAChunk = (chunk) => {
       return fetch(`http://localhost:3001/donations/upload`, {
@@ -94,11 +88,7 @@ const UpdateDb = () => {
       failed()
       console.log(err)
     })
-    .then(results => {
-      console.log(finalResult(results))
-      //handle results here
-
-    });
+    .then(results => success(finalResult(results)));
  
   };
 
@@ -120,13 +110,15 @@ const UpdateDb = () => {
     const totalAmt = extractChunkSummary.reduce((acc, curr)=> {
       return acc.plus(curr.totalAmt)
     }, new BigNumber(0))
+
+    
     return {
       data: flattenDataResponse,
       summary :{
         minDate: minDate.toISOString(),
         maxDate: maxDate.toISOString(),
         totalCount,
-        totalAmt
+        totalAmt: totalAmt.toString()
       }
     }
   }

--- a/src/components/UpdateDB/index.js
+++ b/src/components/UpdateDB/index.js
@@ -8,6 +8,7 @@ import ProgressBar from "./ProgressBar";
 import SuccessUpload from "./Success";
 import FailedImg from "../../images/uploadfail.svg";
 import { dateStringOf } from "../../lib/date.js";
+import BigNumber from 'bignumber.js/bignumber';
 
 const priorUploadState = {
   showPopUp: false,
@@ -80,7 +81,6 @@ const UpdateDb = () => {
           else throw new Error("Error in uploading chunk");
         })
         .then((data) => {
-          console.log(data);
           return data;
         });
     };
@@ -95,13 +95,41 @@ const UpdateDb = () => {
       console.log(err)
     })
     .then(results => {
-      console.log(results)
+      console.log(finalResult(results))
       //handle results here
-      
+
     });
  
   };
 
+  const finalResult = (results) => {
+    console.log(results)
+    const extractDataResponse = results.map(i => i.data)
+    const extractChunkSummary = results.map(i=> i.summary)
+    console.log(extractChunkSummary)
+    const flattenDataResponse = extractDataResponse.reduce((acc, val) => acc.concat(val), []);
+    const maxDate = new Date(Math.max.apply(null, extractChunkSummary.map(function(e) {
+      return new Date(e.maxDate);
+    })));
+    const minDate = new Date(Math.min.apply(null, extractChunkSummary.map(function(e) {
+      return new Date(e.minDate);
+    })));
+    const totalCount = extractChunkSummary.reduce((acc, curr)=> {
+      return  acc + curr.totalCount
+    },0)
+    const totalAmt = extractChunkSummary.reduce((acc, curr)=> {
+      return acc.plus(curr.totalAmt)
+    }, new BigNumber(0))
+    return {
+      data: flattenDataResponse,
+      summary :{
+        minDate: minDate.toISOString(),
+        maxDate: maxDate.toISOString(),
+        totalCount,
+        totalAmt
+      }
+    }
+  }
 
   const failed = () => {
     setUpload({

--- a/src/components/UpdateDB/index.js
+++ b/src/components/UpdateDB/index.js
@@ -84,12 +84,10 @@ const UpdateDb = () => {
         return fetchAChunk(curr).then((result) => [result, ...prevResults]);
       });
     }, Promise.resolve([]))
+    .then(results => success(finalResult(results)))
     .catch((err) => {
-      failed()
-      console.log(err)
+      if (err) failed();
     })
-    .then(results => success(finalResult(results)));
- 
   };
 
   const finalResult = (results) => {


### PR DESCRIPTION
This PR attempts to resolve issue #41 by batching uploads 

The donations are chunked up to arrays of 1000 donations and submitted in batches. 

first batch submitted --> server returns a response 200 --> second batch is submitted ----> server returns a response 200 ----> third batch is submitted , so on and so forth 

if there is error in the donation columns for first batch of uploads , the transaction will rollback and server will return a 500 response and upload will not continue. 

If there is error in the second batch (or subsequent batches), all successful uploads in previous batches WILL NOT be reversed, bcos they are from a separate transaction. Upload will not continue as well. User will be directed to error page (and user will not know that the first batch of upload actually went through) 

